### PR TITLE
add include directory to cmake LLGL target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -600,6 +600,8 @@ else()
     add_library(LLGL SHARED ${FilesLLGL})
 endif()
 
+target_include_directories(LLGL PUBLIC ${PROJECT_INCLUDE_DIR})
+
 if(LLGL_ANDROID_PLATFORM)
     target_link_libraries(LLGL android log)
 elseif(LLGL_IOS_PLATFORM)


### PR DESCRIPTION
This allows to use LLGL as a submodule and library.

For example:
```
add_executable(test main.cpp)
target_link_libraries(projection LLGL)
```

Now #include <LLGL/LLGL.h> works from test.cpp